### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/FreeIva/FreeIva.version
+++ b/GameData/FreeIva/FreeIva.version
@@ -1,6 +1,6 @@
 {
 	"NAME": "FreeIva",
-	"URL": "https://github.com/pizzaoverhead/FreeIva/main/GameData/FreeIva.version",
+	"URL": "https://github.com/pizzaoverhead/FreeIva/raw/main/GameData/FreeIva/FreeIva.version",
 	"DOWNLOAD": "https://github.com/pizzaoverhead/FreeIva/releases",
 	"VERSION":
 	{


### PR DESCRIPTION
Hi @pizzaoverhead and @JonnyOThan,

The version file `URL` property currently is a 404; it's missing `raw` and the folder under `GameData`.

- https://github.com/pizzaoverhead/FreeIva/main/GameData/FreeIva.version

Now it's fixed.

- https://github.com/pizzaoverhead/FreeIva/raw/main/GameData/FreeIva/FreeIva.version

Noticed while reviewing KSP-CKAN/NetKAN#9426.

Cheers!