### PR TITLE
Fixed inconsistencies and typos in ja.cfg

### DIFF
--- a/GameData/FreeIva/Localization/ja.cfg
+++ b/GameData/FreeIva/Localization/ja.cfg
@@ -57,8 +57,8 @@ Localization
         #FreeIVA_PartInfo_CanTraverse_Penalty = #このパーツは、タンク容量の $/FreeIva_AutoPassThrough_VolumePercent$ %を犠牲にして、IVA内で通行可能です。
 
         // PartInfo for Mods
-        #FreeIVA_PartInfo_CanTraverse_Crew = このパーツには、IVAで移動可能なクルー転送用のバリアントがあります。
-        #FreeIVA_PartInfo_CanTraverse_Structural = この部品には、IVAで移動可能な構造バリアントがあります。
+        #FreeIVA_PartInfo_CanTraverse_Crew = このパーツには、IVA で乗員が通行可能なクルー移動バリアントがあります。
+        #FreeIVA_PartInfo_CanTraverse_Structural = このパーツには、IVA で通行可能な構造バリアントがあります。
         
         // Patches AutoPassThrough error check
         #FreeIVA_AutoPassThrough_Errors_Reviva = このパーツのFreeIvaサポートにはRevivaが必要です。

--- a/GameData/FreeIva/Localization/ja.cfg
+++ b/GameData/FreeIva/Localization/ja.cfg
@@ -8,8 +8,8 @@ Localization
         #FreeIVA_Tutorial_Backward = 後方へ進む
         #FreeIVA_Tutorial_StrafeLeft = 左へ進む
        #FreeIVA_Tutorial_StrafeRight =右へ進む
-       #FreeIVA_Tutorial_MoveUp =上に進むする
-       #FreeIVA_Tutorial_MoveDown = 下に進む
+       #FreeIVA_Tutorial_MoveUp =上へ進む
+       #FreeIVA_Tutorial_MoveDown = 下へ進む
        #FreeIVA_Tutorial_Crouch = しゃがむ
        #FreeIVA_Tutorial_ReleaseLadder = 離す
        #FreeIVA_Tutorial_Jump = ジャンプ
@@ -36,8 +36,8 @@ Localization
         #FreeIVA_Message_KermanReturnedSeat = <<1>> が座席に戻った
         #FreeIVA_Message_CamerSwitchtoKerbal = [<<1>>]  <<2>> と席を替わる
         #FreeIVA_Message_PartCannotUnbuckle = このパートではベルトを外すことができません。
-        #FreeIVA_Message_HatchLocked = ハッチがロックされています // 注意：これは一時的な状態を伝えるためのものです。 ロックされたハッチは、他のパーツを展開/格納/伸縮/その他すればロックが解除されます。
-        #FreeIVA_Message_HatchBlocked = ハッチがブロックされています // 注：これは*永久的*な状態を伝えるためのものです。 ブロックされたハッチは、反対側の部品を取り除かない限り開くことができません。
+        #FreeIVA_Message_HatchLocked = ハッチが塞がれています // 注意：これは一時的な状態を伝えるためのものです。 ロックされたハッチは、他のパーツを展開/格納/伸縮/その他すればロックが解除されます。
+        #FreeIVA_Message_HatchBlocked = ハッチが閉鎖されています // 注：これは*永久的*な状態を伝えるためのものです。 ブロックされたハッチは、反対側の部品を取り除かない限り開くことができません。
         #FreeIVA_Message_GoEVA = EVAを開始
         #FreeIVA_Message_CloseHatch = ハッチを閉じる
         #FreeIVA_Message_OpenHatch = ハッチを開ける

--- a/GameData/FreeIva/Localization/ja.cfg
+++ b/GameData/FreeIva/Localization/ja.cfg
@@ -36,8 +36,8 @@ Localization
         #FreeIVA_Message_KermanReturnedSeat = <<1>> が座席に戻った
         #FreeIVA_Message_CamerSwitchtoKerbal = [<<1>>]  <<2>> と席を替わる
         #FreeIVA_Message_PartCannotUnbuckle = このパートではベルトを外すことができません。
-        #FreeIVA_Message_HatchLocked = ハッチが塞がれています // 注意：これは一時的な状態を伝えるためのものです。 ロックされたハッチは、他のパーツを展開/格納/伸縮/その他すればロックが解除されます。
-        #FreeIVA_Message_HatchBlocked = ハッチが閉鎖されています // 注：これは*永久的*な状態を伝えるためのものです。 ブロックされたハッチは、反対側の部品を取り除かない限り開くことができません。
+        #FreeIVA_Message_HatchLocked = 何かでハッチが塞がれています // 注意：これは一時的な状態を伝えるためのものです。 ロックされたハッチは、他のパーツを展開/格納/伸縮/その他すればロックが解除されます。
+        #FreeIVA_Message_HatchBlocked = ハッチが完全に閉鎖されています // 注：これは*永久的*な状態を伝えるためのものです。 ブロックされたハッチは、反対側の部品を取り除かない限り開くことができません。
         #FreeIVA_Message_GoEVA = EVAを開始
         #FreeIVA_Message_CloseHatch = ハッチを閉じる
         #FreeIVA_Message_OpenHatch = ハッチを開ける
@@ -54,11 +54,11 @@ Localization
         // %partInfo = #FreeIVA_PartInfo_CanTraverse_Penalty
         // equals
         // %partInfo = #このパーツは、タンク容量の $/FreeIva_AutoPassThrough_VolumePercent$ %を犠牲にして、IVAで通行可能です。
-        #FreeIVA_PartInfo_CanTraverse_Penalty = #このパーツは、タンク容量の $/FreeIva_AutoPassThrough_VolumePercent$ %を犠牲にして、IVA内で通行可能です。
+        #FreeIVA_PartInfo_CanTraverse_Penalty = #このパーツは、タンク容量の $/FreeIva_AutoPassThrough_VolumePercent$ %を犠牲にして、IVAで通行可能です。
 
         // PartInfo for Mods
-        #FreeIVA_PartInfo_CanTraverse_Crew = このパーツには、IVA で乗員が通行可能なクルー移動バリアントがあります。
-        #FreeIVA_PartInfo_CanTraverse_Structural = このパーツには、IVA で通行可能な構造バリアントがあります。
+        #FreeIVA_PartInfo_CanTraverse_Crew = このパーツには、IVAで通り抜け可能なクルー移乗用バリアントがあります。
+        #FreeIVA_PartInfo_CanTraverse_Structural = このパーツには、IVAで通り抜け可能な構造バリアントがあります。
         
         // Patches AutoPassThrough error check
         #FreeIVA_AutoPassThrough_Errors_Reviva = このパーツのFreeIvaサポートにはRevivaが必要です。

--- a/GameData/FreeIva/Localization/ja.cfg
+++ b/GameData/FreeIva/Localization/ja.cfg
@@ -33,8 +33,8 @@ Localization
         #FreeIVA_Message_Unbuckled = ベルトを外した
         #FreeIVA_Message_Cameralocked = カメラをロックしました
         #FreeIVA_Message_Cameraunlocked = カメラのロックを解除しました
-        #FreeIVA_Message_KermanReturnedSeat = <<1>> が座席に戻った
-        #FreeIVA_Message_CamerSwitchtoKerbal = [<<1>>]  <<2>> と席を替わる
+        #FreeIVA_Message_KermanReturnedSeat = <<1>> が座席に戻った。
+        #FreeIVA_Message_CamerSwitchtoKerbal = [<<1>>] <<2>> と席を替わる
         #FreeIVA_Message_PartCannotUnbuckle = このパーツではベルトを外すことができません
         #FreeIVA_Message_HatchLocked = 何かでハッチが塞がれています // 注意：これは一時的な状態を伝えるためのものです。 ロックされたハッチは、他のパーツを展開/格納/伸縮/その他すればロックが解除されます。
         #FreeIVA_Message_HatchBlocked = ハッチが完全に閉鎖されています // 注：これは*永久的*な状態を伝えるためのものです。 ブロックされたハッチは、反対側の部品を取り除かない限り開くことができません。
@@ -47,8 +47,8 @@ Localization
 
         
         // Part Info texts on the left in VAB/SPH
-        #FreeIVA_PartInfo_CanTraverse = このパーツはIVAで通過できます。
-        #FreeIVA_PartInfo_NotBlockHatch = このパーツはEVAハッチを塞ぎません。
+        #FreeIVA_PartInfo_CanTraverse = このパーツはIVAで通過できます
+        #FreeIVA_PartInfo_NotBlockHatch = このパーツはEVAハッチを塞ぎません
 
         // For other Translators: DO NOT DELETE the "#" symbol -- this is for MM patches in AutoPassThrough.cfg 
         // %partInfo = #FreeIVA_PartInfo_CanTraverse_Penalty

--- a/GameData/FreeIva/Localization/ja.cfg
+++ b/GameData/FreeIva/Localization/ja.cfg
@@ -54,11 +54,11 @@ Localization
         // %partInfo = #FreeIVA_PartInfo_CanTraverse_Penalty
         // equals
         // %partInfo = #このパーツは、タンク容量の $/FreeIva_AutoPassThrough_VolumePercent$ %を犠牲にして、IVAで通行可能です。
-        #FreeIVA_PartInfo_CanTraverse_Penalty = #このパーツは、タンク容量の $/FreeIva_AutoPassThrough_VolumePercent$ %を犠牲にして、IVAで通行可能です。
+        #FreeIVA_PartInfo_CanTraverse_Penalty = #このパーツは、タンク容量の $/FreeIva_AutoPassThrough_VolumePercent$ %を犠牲にして、IVAで通行可能にできます。
 
         // PartInfo for Mods
-        #FreeIVA_PartInfo_CanTraverse_Crew = このパーツには、IVAで通り抜け可能なクルー移乗用バリアントがあります。
-        #FreeIVA_PartInfo_CanTraverse_Structural = このパーツには、IVAで通り抜け可能な構造バリアントがあります。
+        #FreeIVA_PartInfo_CanTraverse_Crew = このパーツには、IVAで通り抜け可能なクルー移乗用バリエーションがあります。
+        #FreeIVA_PartInfo_CanTraverse_Structural = このパーツには、IVAで通り抜け可能な構造バリエーションがあります。
         
         // Patches AutoPassThrough error check
         #FreeIVA_AutoPassThrough_Errors_Reviva = このパーツのFreeIvaサポートにはRevivaが必要です。

--- a/GameData/FreeIva/Localization/ja.cfg
+++ b/GameData/FreeIva/Localization/ja.cfg
@@ -7,26 +7,26 @@ Localization
         #FreeIVA_Tutorial_Forward = 前方へ進む
         #FreeIVA_Tutorial_Backward = 後方へ進む
         #FreeIVA_Tutorial_StrafeLeft = 左へ進む
-       #FreeIVA_Tutorial_StrafeRight =右へ進む
-       #FreeIVA_Tutorial_MoveUp =上へ進む
-       #FreeIVA_Tutorial_MoveDown = 下へ進む
-       #FreeIVA_Tutorial_Crouch = しゃがむ
-       #FreeIVA_Tutorial_ReleaseLadder = 離す
-       #FreeIVA_Tutorial_Jump = ジャンプ
-       #FreeIVA_Tutorial_RollCCW = 左に回転
-       #FreeIVA_Tutorial_RollCW = 右に回転
-       #FreeIVA_Tutorial_ReturnSeat = 座席に戻る
-       #FreeIVA_Tutorial_ToggleGravity = 重力を切り替える。
-       #FreeIVA_Tutorial_Close = 閉じる
-       #FreeIVA_Tutorial_CloseForever = 次回ゲーム起動時まで閉じる
-       #FreeIVA_Tutorial_GrabProp = 小道具ををつかむ
-       #FreeIVA_Tutorial_UseProp = 小道具を使う
-       #FreeIVA_Tutorial_PlaceProp = 小道具を置く
-       #FreeIVA_Tutorial_ThrowProp = 小道具を投げる
+        #FreeIVA_Tutorial_StrafeRight = 右へ進む
+        #FreeIVA_Tutorial_MoveUp = 上へ進む
+        #FreeIVA_Tutorial_MoveDown = 下へ進む
+        #FreeIVA_Tutorial_Crouch = しゃがむ
+        #FreeIVA_Tutorial_ReleaseLadder = 離す
+        #FreeIVA_Tutorial_Jump = ジャンプ
+        #FreeIVA_Tutorial_RollCCW = 反時計回りに回転
+        #FreeIVA_Tutorial_RollCW = 時計回りに回転
+        #FreeIVA_Tutorial_ReturnSeat = 座席に戻る
+        #FreeIVA_Tutorial_ToggleGravity = 重力を切り替える
+        #FreeIVA_Tutorial_Close = 閉じる
+        #FreeIVA_Tutorial_CloseForever = 次回ゲーム起動時まで閉じる
+        #FreeIVA_Tutorial_GrabProp = 小道具を掴む
+        #FreeIVA_Tutorial_UseProp = 小道具を使う
+        #FreeIVA_Tutorial_PlaceProp = 小道具を置く
+        #FreeIVA_Tutorial_ThrowProp = 小道具を投げる
 
         // Screen Message (tips)
         #FreeIVA_Message_GravityEnabled = 重力を有効にしました
-         #FreeIVA_Message_GravityDisabled = 重力を無効にしました
+        #FreeIVA_Message_GravityDisabled = 重力を無効にしました
         #FreeIVA_Message_Unbuckle = ベルトを外す
         #FreeIVA_Message_EnterSeat = 座席に座る
         #FreeIVA_Message_Buckled = ベルトを付けた
@@ -35,7 +35,7 @@ Localization
         #FreeIVA_Message_Cameraunlocked = カメラのロックを解除しました
         #FreeIVA_Message_KermanReturnedSeat = <<1>> が座席に戻った
         #FreeIVA_Message_CamerSwitchtoKerbal = [<<1>>]  <<2>> と席を替わる
-        #FreeIVA_Message_PartCannotUnbuckle = このパートではベルトを外すことができません。
+        #FreeIVA_Message_PartCannotUnbuckle = このパーツではベルトを外すことができません
         #FreeIVA_Message_HatchLocked = 何かでハッチが塞がれています // 注意：これは一時的な状態を伝えるためのものです。 ロックされたハッチは、他のパーツを展開/格納/伸縮/その他すればロックが解除されます。
         #FreeIVA_Message_HatchBlocked = ハッチが完全に閉鎖されています // 注：これは*永久的*な状態を伝えるためのものです。 ブロックされたハッチは、反対側の部品を取り除かない限り開くことができません。
         #FreeIVA_Message_GoEVA = EVAを開始
@@ -47,26 +47,27 @@ Localization
 
         
         // Part Info texts on the left in VAB/SPH
-        #FreeIVA_PartInfo_CanTraverse = このパーツはIVAで移動することができます。
+        #FreeIVA_PartInfo_CanTraverse = このパーツはIVAで通過できます。
         #FreeIVA_PartInfo_NotBlockHatch = このパーツはEVAハッチを塞ぎません。
 
         // For other Translators: DO NOT DELETE the "#" symbol -- this is for MM patches in AutoPassThrough.cfg 
         // %partInfo = #FreeIVA_PartInfo_CanTraverse_Penalty
         // equals
-        // %partInfo = #このパーツは、タンク容量の $/FreeIva_AutoPassThrough_VolumePercent$ %を犠牲にして、IVAで通行可能です。
-        #FreeIVA_PartInfo_CanTraverse_Penalty = #このパーツは、タンク容量の $/FreeIva_AutoPassThrough_VolumePercent$ %を犠牲にして、IVAで通行可能にできます。
+        // %partInfo = #このパーツは、タンク容量の $/FreeIva_AutoPassThrough_VolumePercent$ %を犠牲にして、IVAで通過可能です。
+        #FreeIVA_PartInfo_CanTraverse_Penalty = #このパーツは、タンク容量の $/FreeIva_AutoPassThrough_VolumePercent$ %を犠牲にして、IVAで通過可能にできます。
 
         // PartInfo for Mods
-        #FreeIVA_PartInfo_CanTraverse_Crew = このパーツには、IVAで通り抜け可能なクルー移乗用バリエーションがあります。
-        #FreeIVA_PartInfo_CanTraverse_Structural = このパーツには、IVAで通り抜け可能な構造バリエーションがあります。
+        #FreeIVA_PartInfo_CanTraverse_Crew = このパーツには、IVAで通過可能なクルー移乗用バリエーションがあります。
+        #FreeIVA_PartInfo_CanTraverse_Structural = このパーツには、IVAで通過可能な構造バリエーションがあります。
         
         // Patches AutoPassThrough error check
         #FreeIVA_AutoPassThrough_Errors_Reviva = このパーツのFreeIvaサポートにはRevivaが必要です。
         #FreeIVA_AutoPassThrough_Errors_B9PartSwitch = このパーツのFreeIvaサポートにはB9PartSwitchが必要です。
-        #FreeIVA_AutoPassThrough_Errors_ConfigurableContainers =このパーツのFreeIvasサポートはConfigurableContainersと互換性がありません。
+        #FreeIVA_AutoPassThrough_Errors_ConfigurableContainers = このパーツのFreeIvaサポートはConfigurableContainersと互換性がありません。
         #FreeIVA_AutoPassThrough_Errors_ModularFuelTanks = このパーツのFreeIvaサポートはModularFuelTanksと互換性がありません。
         #FreeIVA_AutoPassThrough_Errors_InterstellarFuelSwitch = このパーツのFreeIvaサポートはInterstellarFuelSwitchと互換性がありません。
         #FreeIVA_AutoPassThrough_Errors_SimpleFuelSwitch = このパーツのFreeIvaサポートはSimpleFuelSwitchと互換性がありません。
+        #FreeIVA_Support_Requires_HabTechProps = このパーツのFreeIvaサポートにはHabTechPropsが必要です。
 
         // B9 Part Switcher Variants
         #FreeIVA_Switcher_Blocked = 通過不可


### PR DESCRIPTION
This pull request updates the Japanese localization file for the FreeIVA mod, focusing on improving translation accuracy, clarity, and consistency in terminology. The changes primarily refine tutorial instructions, system messages, and part information texts to better match the intended meaning and context.

**Tutorial and Instruction Text Improvements:**

* Corrected several tutorial action descriptions for clarity and natural Japanese phrasing, such as movement directions and rotation instructions.

**System Message Refinements:**

* Updated various system messages to use more accurate terminology (e.g., changing "パート" to "パーツ") and clarified hatch status messages for temporary and permanent conditions.

**Part Information and Compatibility Updates:**

* Improved part info texts for readability and consistency, including changes to how traversal and compatibility are described.
* Added a new error message for missing `HabTechProps` support in parts.